### PR TITLE
Phase 1: fix bugs, security, code quality, and HTML/JS issues

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,16 @@ dictConfig({
 
 import flask
 app = flask.Flask(__name__)
-app.secret_key = 'allyourbasearebelongtous'
+
+_secret_key = os.environ.get('IMAGELIB_SECRET_KEY')
+if not _secret_key:
+    _key_file = os.path.join(prodhome, '.secret_key') if os.path.exists(prodhome) else '.secret_key'
+    if os.path.exists(_key_file):
+        with open(_key_file) as _f:
+            _secret_key = _f.read().strip()
+if not _secret_key:
+    raise RuntimeError('Set IMAGELIB_SECRET_KEY env var or create .secret_key file')
+app.secret_key = _secret_key
 
 import markup
 markup = markup.Markup()
@@ -37,7 +46,7 @@ markup = markup.Markup()
 
 @app.route('/', methods=['GET','POST'])
 def top():
-    print("Args: ", flask.request.args.to_dict(), " Form: ", flask.request.form.to_dict())
+    app.logger.debug("Args: {}  Form: {}".format(flask.request.args.to_dict(), flask.request.form.to_dict()))
     t = markup.build_images(start = flask.request.form.get('start'),
                             target = flask.request.form.get('target'),
                             imgfilter = flask.request.form.get('imgfilter'),
@@ -46,17 +55,17 @@ def top():
 
 @app.route('/search', methods=['GET','POST'])
 def search():
-    print("Args: ", flask.request.args.to_dict(), " Form: ", flask.request.form.to_dict())
+    app.logger.debug("Args: {}  Form: {}".format(flask.request.args.to_dict(), flask.request.form.to_dict()))
     target = flask.request.args.get('target')
-    app.logger.info("DEBUG: search target={}".format(target))
+    app.logger.debug("search target={}".format(target))
     t = markup.build_images(target = target)
     return flask.render_template('imagelib.html', **t)
 
 @app.route('/download', methods=['GET','POST'])
 def download():
-    app.logger.info("DEBUG: download({})".format(flask.request.form.get('recids')))
+    app.logger.debug("download({})".format(flask.request.form.get('recids')))
     tempfn = markup.zipit(flask.request.form.get('recids'))
-    app.logger.info("DEBUG: sending {}".format(tempfn))
+    app.logger.debug("sending {}".format(tempfn))
     response = flask.send_file(tempfn, as_attachment=True)
     return response
     # unlink(tempfn)
@@ -64,7 +73,7 @@ def download():
 @app.route('/deets', methods=['GET'])
 def deets():
     recid = flask.request.args.get('recid')
-    app.logger.info("DEBUG: deets({})".format(recid))
+    app.logger.debug("deets({})".format(recid))
     return flask.render_template_string(markup.fetchDeets(recid))
 
 @app.route('/favicon.ico')

--- a/__init__.py
+++ b/__init__.py
@@ -26,12 +26,13 @@ dictConfig({
 import flask
 app = flask.Flask(__name__)
 
-_secret_key = os.environ.get('IMAGELIB_SECRET_KEY')
-if not _secret_key:
-    _key_file = os.path.join(prodhome, '.secret_key') if os.path.exists(prodhome) else '.secret_key'
-    if os.path.exists(_key_file):
-        with open(_key_file) as _f:
-            _secret_key = _f.read().strip()
+_key_file = os.path.join(prodhome, '.secret_key') if os.path.exists(prodhome) else '.secret_key'
+_secret_key = None
+if os.path.exists(_key_file):
+    with open(_key_file) as _f:
+        _secret_key = _f.read().strip()
+if os.environ.get('IMAGELIB_SECRET_KEY'):
+    _secret_key = os.environ['IMAGELIB_SECRET_KEY']
 if not _secret_key:
     raise RuntimeError('Set IMAGELIB_SECRET_KEY env var or create .secret_key file')
 app.secret_key = _secret_key

--- a/catalog.py
+++ b/catalog.py
@@ -28,7 +28,7 @@ class Catalog:
 
     re_messier = re.compile('^M \d+$')
 
-    db = fitsdb.Fitsdb()
+    db = None
 
     def init(self):
         logging.debug(">>> Connecting to database")
@@ -45,8 +45,8 @@ class Catalog:
     def cname(cls, object):
         '''Return the canonical name for `object`.'''
         logging.debug(">>> cname({})".format(object))
-        if (not cls.db):
-            cls.__init__()
+        if cls.db is None:
+            cls.db = fitsdb.Fitsdb()
         cur = cls.db.con.cursor()
         sql = "select cname from catalog_by_target where target = ?"
         logging.debug(">>> {} WITH {}".format(sql, object))
@@ -93,132 +93,132 @@ if (__name__ == "__main__"):
             print(usage)
             sys.exit(1)
 
-        file = open(catalogfile)
-        cur = db.con.cursor()
+        with open(catalogfile) as file:
+            cur = db.con.cursor()
 
-        if (cmd == 'recreate'):
-            error = None
-            for table in [ 'catalog', 'catalog_by_target' ]:
-                sql = "DROP TABLE {}".format(table)
-                logging.debug(">>> {}".format(sql))
-                try:
-                    cur.execute(sql)
-                    db.con.commit()
-                    print("Table {} dropped".format(table))
-                except sqlite3.Error as er:
-                    print('ERROR: ' + ' '.join(er.args))
-                    if (er.args[0][0:14] == 'no such table:'):
-                        error = 1
-            if (error):
-                print('You meant maybe `create` instead?')
-                sys.exit(1)
-
-        # Parse header into a list (and build our qmarks)
-        headerline = file.readline().rstrip().replace('"','').lower()
-        header = list()
-        qmarks = list()
-        for hdr in headerline.split(','):
-            header.append(cat.prettyspace(hdr).replace(' ','_'))  # boo!
-            qmarks.append('?')
-        logging.debug(">>> headerline: {}$".format(headerline))
-        logging.debug(">>> header: ({}) {}".format(len(header), header))
-        logging.debug(">>> qmarks: ({}) {}".format(len(qmarks), qmarks))
-
-        # Build sql CREATE statement based on columns called out in headerfile
-        # Note that `object`, `other` and `type` have to exist or Bad Things will happen
-        cols = list()
-        cols.append('id INTEGER PRIMARY KEY AUTOINCREMENT')
-        for hdr in header:
-            cols.append('{} TEXT'.format(hdr))
-        sql = 'CREATE TABLE catalog ({}\n)'.format(',\n  '.join(cols))
-        logging.debug(">>> {}".format(sql))
-
-        # Intentionally fail if table exists
-        try:
-            cur.execute(sql)
-            cur.execute("CREATE UNIQUE INDEX catalog_object_index ON catalog (object)")
-            cur.execute("CREATE INDEX catalog_type_index ON catalog (type)")
-            cur.execute("CREATE TABLE catalog_by_target ( target TEXT, id INTEGER, cname TEXT )")
-            cur.execute("CREATE INDEX catalog_by_target_target_index ON catalog_by_target (target)")
-            cur.execute("CREATE INDEX catalog_by_target_id_index ON catalog_by_target (id)")
-            db.con.commit()
-        except sqlite3.Error as er:
-            print('ERROR: ' + ' '.join(er.args))
-            if (er.args[0] == 'table catalog already exists'):
-                print("HINT: If you really want to recreate it, rerun using `recreate`")
-            sys.exit(1)
-
-        print("Tables catalog, catalog_by_target created")
-
-        # Insert data
-        linenum = 1  # We already processed header
-        insertCount = 0
-        aliasCount = 0
-        datalines = file.readlines()
-        for dataline in datalines:
-            linenum += 1
-
-            # Twiddle the data
-            logging.debug(">>> dataline: {}".format(dataline))
-            data = list()
-            for d in dataline.rstrip().split('","'):
-                data.append(cat.prettyspace(d))
-            logging.debug(">>> data: {}".format(data))
-            if (len(data) != len(header)):
-                print("Not enough fields at line {}; skipping (found {} expected {})".format(linenum, len(data), len(header)))
-                next
-
-            # Insert into catalog
-            sql = 'INSERT INTO catalog ({}) VALUES ({})'.format(','.join(header), ','.join(qmarks))
-            logging.debug(">>> {}".format(sql))
-            try:
-                cur.execute(sql, data)
-                # db.con.commit()
-                id = cur.lastrowid
-                insertCount += 1
-            except sqlite3.Error as er:
-                if (er.args[0] == 'UNIQUE constraint failed: catalog.object'):
-                    print("Duplicate {} entry found at line {}; skipping".format(data[0], linenum))
-                    insertCount -= 1
-                else:
-                    print('ERROR: ' + ' '.join(er.args))
+            if (cmd == 'recreate'):
+                error = None
+                for table in [ 'catalog', 'catalog_by_target' ]:
+                    sql = "DROP TABLE {}".format(table)
+                    logging.debug(">>> {}".format(sql))
+                    try:
+                        cur.execute(sql)
+                        db.con.commit()
+                        print("Table {} dropped".format(table))
+                    except sqlite3.Error as er:
+                        print('ERROR: ' + ' '.join(er.args))
+                        if (er.args[0][0:14] == 'no such table:'):
+                            error = 1
+                if (error):
+                    print('You meant maybe `create` instead?')
                     sys.exit(1)
 
-            # Get all our possible names
-            targets = [ data[0] ]           # [0] is object
-            for alt in data[1].split(';'):  # [1] is `other` name(s) for object
-                targets.append(alt)
+            # Parse header into a list (and build our qmarks)
+            headerline = file.readline().rstrip().replace('"','').lower()
+            header = list()
+            qmarks = list()
+            for hdr in headerline.split(','):
+                header.append(cat.prettyspace(hdr).replace(' ','_'))  # boo!
+                qmarks.append('?')
+            logging.debug(">>> headerline: {}$".format(headerline))
+            logging.debug(">>> header: ({}) {}".format(len(header), header))
+            logging.debug(">>> qmarks: ({}) {}".format(len(qmarks), qmarks))
 
-            # Figure out canonical name
-            cname = data[0]                 # default to `object`
-            for target in targets:
-                if (cat.re_messier.match(target)):
-                    cname = target          # override with Messier
-                    break
+            # Build sql CREATE statement based on columns called out in headerfile
+            # Note that `object`, `other` and `type` have to exist or Bad Things will happen
+            cols = list()
+            cols.append('id INTEGER PRIMARY KEY AUTOINCREMENT')
+            for hdr in header:
+                cols.append('{} TEXT'.format(hdr))
+            sql = 'CREATE TABLE catalog ({}\n)'.format(',\n  '.join(cols))
+            logging.debug(">>> {}".format(sql))
 
-            # Add all our names to lookup table
-            for target in targets:
-                if (target):
-                    sql = "insert into catalog_by_target (target, id, cname) values (?,?,?)"
-                    logging.debug(">>> {} {}".format(sql, [ target, id, cname ]))
-                    cur.execute(sql, [ target, id, cname ])
-                    aliasCount += 1
+            # Intentionally fail if table exists
+            try:
+                cur.execute(sql)
+                cur.execute("CREATE UNIQUE INDEX catalog_object_index ON catalog (object)")
+                cur.execute("CREATE INDEX catalog_type_index ON catalog (type)")
+                cur.execute("CREATE TABLE catalog_by_target ( target TEXT, id INTEGER, cname TEXT )")
+                cur.execute("CREATE INDEX catalog_by_target_target_index ON catalog_by_target (target)")
+                cur.execute("CREATE INDEX catalog_by_target_id_index ON catalog_by_target (id)")
+                db.con.commit()
+            except sqlite3.Error as er:
+                print('ERROR: ' + ' '.join(er.args))
+                if (er.args[0] == 'table catalog already exists'):
+                    print("HINT: If you really want to recreate it, rerun using `recreate`")
+                sys.exit(1)
 
-        db.con.commit()
-        print("{} catalog entries added".format(insertCount))
-        print("{} target aliases added".format(aliasCount))
-        db.con.close()
-        sys.exit()
+            print("Tables catalog, catalog_by_target created")
+
+            # Insert data
+            linenum = 1  # We already processed header
+            insertCount = 0
+            aliasCount = 0
+            datalines = file.readlines()
+            for dataline in datalines:
+                linenum += 1
+
+                # Twiddle the data
+                logging.debug(">>> dataline: {}".format(dataline))
+                data = list()
+                for d in dataline.rstrip().split('","'):
+                    data.append(cat.prettyspace(d))
+                logging.debug(">>> data: {}".format(data))
+                if (len(data) != len(header)):
+                    print("Not enough fields at line {}; skipping (found {} expected {})".format(linenum, len(data), len(header)))
+                    continue
+
+                # Insert into catalog
+                sql = 'INSERT INTO catalog ({}) VALUES ({})'.format(','.join(header), ','.join(qmarks))
+                logging.debug(">>> {}".format(sql))
+                try:
+                    cur.execute(sql, data)
+                    # db.con.commit()
+                    id = cur.lastrowid
+                    insertCount += 1
+                except sqlite3.Error as er:
+                    if (er.args[0] == 'UNIQUE constraint failed: catalog.object'):
+                        print("Duplicate {} entry found at line {}; skipping".format(data[0], linenum))
+                        insertCount -= 1
+                    else:
+                        print('ERROR: ' + ' '.join(er.args))
+                        sys.exit(1)
+
+                # Get all our possible names
+                targets = [ data[0] ]           # [0] is object
+                for alt in data[1].split(';'):  # [1] is `other` name(s) for object
+                    targets.append(alt)
+
+                # Figure out canonical name
+                cname = data[0]                 # default to `object`
+                for target in targets:
+                    if (cat.re_messier.match(target)):
+                        cname = target          # override with Messier
+                        break
+
+                # Add all our names to lookup table
+                for target in targets:
+                    if (target):
+                        sql = "insert into catalog_by_target (target, id, cname) values (?,?,?)"
+                        logging.debug(">>> {} {}".format(sql, [ target, id, cname ]))
+                        cur.execute(sql, [ target, id, cname ])
+                        aliasCount += 1
+
+            db.con.commit()
+            print("{} catalog entries added".format(insertCount))
+            print("{} target aliases added".format(aliasCount))
+            db.con.close()
+            sys.exit()
 
     elif (cmd == 'stats'):
         cur = db.con.cursor()
         total_rows = cur.execute("select count(*) from catalog").fetchone()[0]
         total_aliases = cur.execute("select count(*) from catalog_by_target").fetchone()[0]
 
-        type = dict()
+        type_counts = dict()
         sql = 'select type, count(type) from catalog group by 1 order by 2 desc'
         for row in cur.execute(sql).fetchall():
-            type[row[0]] = row[1]
+            type_counts[row[0]] = row[1]
 
         con = dict()
         sql = 'select con, count(con) from catalog group by 1 order by 2 desc'
@@ -226,9 +226,9 @@ if (__name__ == "__main__"):
             con[row[0]] = row[1]
 
         print("The catalog contains {:,} objects with {:,} aliases".format(total_rows, total_aliases))
-        print("\nThere are {} types of objects:".format(len(type)))
+        print("\nThere are {} types of objects:".format(len(type_counts)))
         x = 0
-        for t,v in type.items():
+        for t,v in type_counts.items():
             x += 1
             print("{:-5d} {:10s}".format(v,t), end='')
             if (x >= 8):
@@ -249,7 +249,7 @@ if (__name__ == "__main__"):
         sys.exit(0)
 
     elif (cmd == 'query'):
-        print("Wuery not yet implemented.")
+        print("Query not yet implemented.")
         #  object TEXT,
         #  other TEXT,
         #  type TEXT,

--- a/fitsdb.py
+++ b/fitsdb.py
@@ -25,11 +25,6 @@ class Fitsdb:
     def __del__(self):
         self.con.close()
 
-    def execute_and_commit(self, sql):
-        cur = self.con.cursor()
-        cur.execute(sql)
-        self.con.commit()
-
     def insert(self, image):
         '''Insert image (dictionary) into the database.'''
         logging.debug(">>> fitsdb.insert(): imagetype: {}".format(image['imagetype']))

--- a/fitsfiles.py
+++ b/fitsfiles.py
@@ -131,6 +131,8 @@ class FitsFiles:
         # --- WORKAROUND: Rename the file temporarily to a simple name ---
         # Create a safe, temporary filename within the same directory
         temp_safe_fits_path = os.path.join(fits_dir, "temp_safe_image.fits")
+        temp_safe_preview = None
+        temp_safe_thumb = None
 
         try:
             # Rename the complex file path to the simple file path
@@ -180,7 +182,7 @@ class FitsFiles:
 
         return record
 
-    def addFitsFile(self, filename):
+    def addFitsFile(self, filename, db):
         filename = filename.rstrip()
         if (not os.path.exists(filename)):
             print("Skipping {}: File not found!".format(filename))
@@ -193,7 +195,7 @@ class FitsFiles:
         record = self.buildDatabaseRecord(filename, headers)
         logging.debug(">>> addFitsFile: imagetype: {}".format(record['imagetype']))
         record = self.fits2png(record)
-        rowid = fitsdb.insert(record)
+        rowid = db.insert(record)
         if (rowid):
             return(1)
         else:
@@ -206,29 +208,33 @@ class FitsFiles:
             # Skip all the find logic and just add files
             count = 0
             for filename in files:
-                count += self.addFitsFile(filename)
+                count += self.addFitsFile(filename, fitsdb)
             return(count)
 
         # Build the find command
         start_time = datetime.datetime.now()  # On the off chance new files come in during find
-        newer_arg = '';
-        if (os.path.exists(fitsdb.tsfile)):
-            newer_arg = '-newer ' + fitsdb.tsfile
-        name_tests = ' -o '.join([f"-name '{p}'" for p in self.FILE_PATTERNS])
-        find_cmd = f"find {path} {newer_arg} -type f -a \( {name_tests} \)"
-        logging.debug(f">>> {find_cmd}")
+        find_cmd = ['find', path]
+        if os.path.exists(fitsdb.tsfile):
+            find_cmd += ['-newer', fitsdb.tsfile]
+        name_args = []
+        for pattern in self.FILE_PATTERNS:
+            if name_args:
+                name_args.append('-o')
+            name_args += ['-name', pattern]
+        find_cmd += ['-type', 'f', '-a', '('] + name_args + [')']
+        logging.debug(">>> {}".format(find_cmd))
 
         # Do the find comamand
         count = 0
-        with os.popen(find_cmd) as find_out:
-            for filename in find_out:
-                count += self.addFitsFile(filename)
+        result = subprocess.run(find_cmd, capture_output=True, text=True)
+        for filename in result.stdout.splitlines():
+            if filename:
+                count += self.addFitsFile(filename, fitsdb)
 
         # Update the timestamp with our start time, but only if successful
         if (count > 0):
             timestamp = start_time.strftime("%Y%m%d%H%M.%S")  # [[CC]YY]MMDDhhmm[.ss]
-            cmd = "touch -t {} {}".format(timestamp, fitsdb.tsfile)
-            os.system(cmd)
+            subprocess.run(['touch', '-t', timestamp, fitsdb.tsfile])
 
         return(count)
 

--- a/markup.py
+++ b/markup.py
@@ -23,13 +23,13 @@ class Markup:
         version_fn = 'VERSION' if os.path.exists('VERSION') else '/home/nas/flask/imagelib/VERSION'
         with open(version_fn, 'r') as vfile:
             self.version = vfile.readline().strip()
-        print(">>> Markup version {}; connected to {}".format(self.version, self.db))
-        print(">>> Working directory: {}".format(os.getcwd()))
+        logging.info("Markup version {}; connected to {}".format(self.version, self.db))
+        logging.info("Working directory: {}".format(os.getcwd()))
 
     def reset(self):
         '''Reset lists each time we're called.'''
-        print('>>> markup.reset()')
-        self.where_list = list()  # Where clause
+        logging.debug("markup.reset()")
+        self.where_list = list()  # List of (clause, params) tuples
         self.what_list = list()   # Human description for page title
 
         # Collect some stats
@@ -39,11 +39,17 @@ class Markup:
         self.total_tgts = cur.execute("select count(*) from fits where imagetype = 'tgt'").fetchone()[0]
         self.distinct_tgts = cur.execute("select count(distinct(target)) from fits where imagetype = 'tgt'").fetchone()[0]
 
-    def add_where(self, w):
-        self.where_list.append(w)
+    def add_where(self, clause, params=None):
+        self.where_list.append((clause, params or []))
 
     def get_where(self):
-        return(' AND '.join(self.where_list))
+        return ' AND '.join(clause for clause, _ in self.where_list)
+
+    def get_params(self):
+        result = []
+        for _, params in self.where_list:
+            result.extend(params)
+        return result
 
     def add_what(self, w):
         self.what_list.append(w)
@@ -52,26 +58,28 @@ class Markup:
         return(' '.join(self.what_list))
 
     def buildWhere_imgfilter(self, imgfilter):
-        '''Upeate where clause to restrict by imgfilter if either cal or tgt selected. (Both doesn't require a where clause.)'''
+        '''Update where clause to restrict by imgfilter if either cal or tgt selected. (Both doesn't require a where clause.)'''
         if (imgfilter == 'cal'):
-            self.add_where('imagetype = "cal"')
+            self.add_where('imagetype = ?', ['cal'])
             self.add_what('Calibration:')
         elif (imgfilter == 'tgt'):
-            self.add_where('imagetype = "tgt"')
+            self.add_where('imagetype = ?', ['tgt'])
             self.add_what('Target:')
 
     def buildWhere_target(self, target):
-        '''Update where cluse to match target if exact match, else do a fuzzy lookup.'''
+        '''Update where clause to match target if exact match, else do a fuzzy lookup.'''
         if (target):
             cur = self.db.con.cursor()
             sql = "select count(*) from fits where target = ?"
+            params = [target]
             if (self.where_list):
                 sql += " and {}".format(self.get_where())
-            if (cur.execute(sql, [ target ]).fetchone()[0] > 0):
-                self.add_where('target = "{}"'.format(target))  # Query above untaints target
+                params += self.get_params()
+            if (cur.execute(sql, params).fetchone()[0] > 0):
+                self.add_where('target = ?', [target])
                 self.add_what(target)
             else:
-                self.add_where('target like "%{}%"'.format(target))
+                self.add_where('target like ?', ['%' + target + '%'])
                 self.add_what('matching <{}>'.format(target))
 
         if (not self.what_list):
@@ -80,53 +88,60 @@ class Markup:
     def fetchTargets(self, target=None):
         '''Return list of distinct targets that match, handling empty target and fuzzy matches.'''
         sql = "SELECT DISTINCT(target) FROM fits"
+        params = []
         if (self.where_list):
             sql += " WHERE {}".format(self.get_where())
+            params = self.get_params()
         sql += ' ORDER BY target'
 
         logging.debug(">>> {}".format(sql))
         cur = self.db.con.cursor()
-        cur.execute(sql)
+        cur.execute(sql, params)
         targets = list()
         for row in cur.fetchall():
             targets.append(row[0])
-        print(">>> fetchTargets({}) ==> {} rows".format(target, len(targets)))
+        logging.debug("fetchTargets({}) ==> {} rows".format(target, len(targets)))
         return(targets)
 
     def fetchDates(self, target=None):
         '''Return list of distinct dates for this target, handling empty target and fuzzy matches.'''
         sql = "SELECT DISTINCT(date) FROM fits"
+        params = []
         if (self.where_list):
             sql += " WHERE {}".format(self.get_where())
+            params = self.get_params()
         sql += " ORDER BY date DESC"
 
         logging.debug(">>> {}".format(sql))
         cur = self.db.con.cursor()
-        cur.execute(sql)
+        cur.execute(sql, params)
         dates = list()
         for row in cur.fetchall():
             dates.append(row[0])
-        print(">>> fetchDates({}) ==> {} rows".format(target, len(dates)))
+        logging.debug("fetchDates({}) ==> {} rows".format(target, len(dates)))
         return(dates)
 
     def fetchDetails(self, target=None, date=None):
         '''Return list of details (tuple) that match target and date.'''
         cur = self.db.con.cursor()
         sql = "SELECT id, target, thumbnail, preview FROM fits"
+        params = []
         if (self.where_list):
             sql += " WHERE {}".format(self.get_where())
             sql += " AND date = ?"
+            params = self.get_params() + [date]
         else:
             sql += " WHERE date = ?"
+            params = [date]
         sql += " ORDER BY id"
 
-        logging.debug(">>> {} with ({})".format(sql,date))
+        logging.debug(">>> {} with ({})".format(sql, date))
         cur = self.db.con.cursor()
-        cur.execute(sql, [date])
+        cur.execute(sql, params)
         details = list()
         for row in cur.fetchall():
             details.append(row)
-        print(">>> fetchDetails(t:{}, d:{}) ==> {} rows".format(target, date, len(details)))
+        logging.debug("fetchDetails(t:{}, d:{}) ==> {} rows".format(target, date, len(details)))
         return(details)
 
     def findStartDate(self, dates, start):
@@ -138,9 +153,9 @@ class Markup:
                     break
                 startX += 1
         if (startX >= len(dates)):
-            print(">>> start date {} not found".format(start))
+            logging.warning("start date {} not found".format(start))
             startX = 0
-        print(">>> findStartDate({}) ==> {}".format([len(dates), start], startX))
+        logging.debug("findStartDate({}) ==> {}".format([len(dates), start], startX))
         return(startX)
 
     def noneify(self, var):
@@ -154,7 +169,7 @@ class Markup:
     # Main UI entrypoint
     def build_images(self, start=None, target=None, imgfilter='both', lastTarget=None):
         '''Build a template (dictionary) of which images to display.'''
-        print(">>> build_images(start={}, target={}, imgfilter={}, lastTarget={})".format(start,target,imgfilter,lastTarget))
+        logging.debug("build_images(start={}, target={}, imgfilter={}, lastTarget={})".format(start,target,imgfilter,lastTarget))
         self.reset()
 
         images = dict()
@@ -176,7 +191,7 @@ class Markup:
         targets = self.fetchTargets(target)
         if (len(targets) == 0):
             # Flash an error and refetch lastTarget
-            print(">>> target not found")
+            logging.warning("target not found")
             flask.flash("Target '{}' not found".format(target))
             target = lastTarget
             targets = self.fetchTargets(target)
@@ -186,7 +201,7 @@ class Markup:
 
         # Reset date if new target chosen
         if (self.noneify(lastTarget) != self.noneify(target)):
-            print(">>> lastTarget:{} != target:{} ==> start:None".format(lastTarget, target))
+            logging.debug("lastTarget:{} != target:{} ==> start:None".format(lastTarget, target))
             images['start'] = ''
             start = None
 
@@ -198,8 +213,8 @@ class Markup:
             images['prev'] = dates[startX - 1]
         images['obsDates'] = dates
 
-        print(">>> dates: ({} of 'em)".format(len(dates)))
-        print(">>> start: {}".format(start))
+        logging.debug("dates: ({} of 'em)".format(len(dates)))
+        logging.debug("start: {}".format(start))
         images['title'] = "RFO Image Library: {}".format(self.get_what())  # set in searchType() as a side effect of any fetchXxx() call
 
         thumb_count = 0
@@ -235,21 +250,20 @@ class Markup:
                 pic['recid'] = recid
                 pic['title'] = thisTarget
                 pic['src'] = thumbnail
-                pic['preview'] = preview  # Not used cuz I couln't figure out how to sneak it in
                 collection['pics'].append(pic)
 
             images['collections'].append(collection)
 
         for thang in [ 'target', 'date', 'start', 'prev', 'next' ]:
             if (thang in images):
-                print(">>> images[{}]: {}".format(thang, images[thang]))
+                logging.debug("images[{}]: {}".format(thang, images[thang]))
 
         # print(json.dumps(images, indent=4))
         return(images)
 
     def zipit(self, recidstr):
         '''Query the database for specified record IDs, zip up the fits files and return zip file path.'''
-        print(">>> zipit({})".format(recidstr))
+        logging.debug("zipit({})".format(recidstr))
         recids = recidstr.split(',')
         qmarks = list()
         for x in recids:
@@ -258,9 +272,9 @@ class Markup:
 
         cur = self.db.con.cursor()
         sql = "select id, path from fits where id in ({}) order by id".format(questionmarks)
-        print(">>> {} [{}]".format(sql,recids))
+        logging.debug("{} [{}]".format(sql, recids))
         rows = cur.execute(sql, recids)
-        print(">>> returned {} rows".format(rows.rowcount))
+        logging.debug("returned {} rows".format(rows.rowcount))
 
         # Experiments show that at compressionlevel=1, the zip file is 3% larger than at =9, but 9 takes 5 times as long
         self.sequence += 1
@@ -270,11 +284,10 @@ class Markup:
             os.remove(tempfn)
         with zipfile.ZipFile(tempfn, mode='x', compression=zipfile.ZIP_DEFLATED, compresslevel=1) as zip:
             for row in rows:
-                print(">>> adding {}".format(row))
+                logging.debug("adding {}".format(row))
                 id, path = row
                 zip.write(path, arcname=os.path.basename(path))
-        zip.close()
-        print(">>> return({})".format(tempfn))
+        logging.debug("return({})".format(tempfn))
         return(tempfn)
 
     def fetchDeets(self, recid):

--- a/static/imagelib.js
+++ b/static/imagelib.js
@@ -101,7 +101,7 @@ function setRecids() {
     }
 }
 
-/* Reutrn just the filename component of a full path */
+/* Return just the filename component of a full path */
 function basename(path) {
    return path.split('/').reverse()[0];
 }
@@ -110,14 +110,14 @@ function basename(path) {
 function keydownHandler(event) {
     console.log("keydownHandler(" + event + ")");
     if (document.getElementById("preview-container").style.display == "block") {
-        if (event.keyCode === 27) {  // <ESC> keycode
+        if (event.key === 'Escape') {
             closePreview();
-        } else if (event.keyCode === 32) {  // <SPACE> keycode
+        } else if (event.key === ' ') {
             toggleSelect(previewElement, -1);
         }
     }
     if (document.getElementById("help-container").style.display == "block") {
-        if (event.keyCode === 27) {  // <ESC> keycode
+        if (event.key === 'Escape') {
             closeHelp();
         }
     }
@@ -159,8 +159,8 @@ function preview(el) {
 }
 
 /* Special flavor of toggle() that also colors the preview border */
-function toggleSelect(el) {
-    select(el, -1);
+function toggleSelect(el, mode) {
+    select(el, mode);
     document.getElementById("preview-content").style.borderColor = document.getElementById(el).rfoIsSelected ? color_selected : color_unselected;
 }
 
@@ -181,7 +181,7 @@ function help() {
         }
     };
     xhttp.open("GET", "static/help.html", true);
-    console.log("fetching static/help.hmtl");
+    console.log("fetching static/help.html");
     xhttp.send();
     document.addEventListener("keydown", keydownHandler);
     document.getElementById("help-container").style.display = "block";

--- a/templates/imagelib.html
+++ b/templates/imagelib.html
@@ -25,7 +25,7 @@
                 <div class="homebuttons" id="homebuttons">
                     <!-- buttons line one -->
                     <span class="right">
-                        <span class="right"><a href='/' alt='Home'><image src="static/home.png" height="28" alt="[Home]"></a></span>
+                        <span class="right"><a href='/' alt='Home'><img src="static/home.png" height="28" alt="[Home]"></a></span>
                         <span class="right"><img src="static/1x1-transparent.png" width="8" height="1"></span>
                         <span class="right">
                             <form name="dlform" method="POST" onSubmit="return(setRecids());" action="/download">
@@ -34,7 +34,7 @@
                             </form>
                         </span>
                         <span class="right"><img src="static/1x1-transparent.png" width="8" height="1"></span>
-                        <span class="right"><image src="static/help.png" height="28" alt="[Help]" onClick="help()"></span>
+                        <span class="right"><img src="static/help.png" height="28" alt="[Help]" onClick="help()"></span>
                     </span>
 
                     <!-- buttons line two -->
@@ -101,19 +101,17 @@
                     </span>
 
                     <!-- Filter line 3: Possible messages -->
-                    {% if messages %}
+                    {% with messages = get_flashed_messages() %}
+                     {% if messages %}
                       <br/>
                       <span class="right"><img src="static/1x1-transparent.png" width="22" height="1"></span>
                       <span class="message">
-                      {% with messages = get_flashed_messages() %}
-                       {% if messages %}
-                        {% for message in messages %}
-                          <font color="brown">{{ message }}</font><br/>
-                        {% endfor %}
-                       {% endif %}
-                      {% endwith %}
+                       {% for message in messages %}
+                        <span style="color:brown">{{ message }}</span><br/>
+                       {% endfor %}
                       </span>
-                    {% endif %}
+                     {% endif %}
+                    {% endwith %}
 
                 </div>
             </div>


### PR DESCRIPTION
Bugs:
- Pass Fitsdb instance explicitly into addFitsFile() (was relying on global name reassignment that worked by accident)
- catalog.py: replace bare `next` (no-op) with `continue` so malformed catalog lines are actually skipped
- imagelib.html: remove outer {% if messages %} guard that prevented flashed messages from ever rendering
- fitsfiles.py: initialize temp_safe_preview/thumb to None before try block to prevent NameError in finally clause

Security:
- markup.py: refactor where_list to carry (clause, params) tuples; all user-controlled values now use parameterized queries, fixing SQL injection in the fuzzy LIKE target search
- __init__.py: load secret_key from IMAGELIB_SECRET_KEY env var or .secret_key file; fail at startup if neither is present

Structural:
- catalog.py: lazy-initialize Catalog.db in cname() instead of at import time (importing catalog no longer opens a DB connection)
- fitsdb.py: remove unused execute_and_commit() method

Code quality:
- markup.py: convert all print() calls to logging.debug/info/warning
- __init__.py: remove "DEBUG:" prefix from log messages; replace print() request logging with app.logger.debug()
- fitsfiles.py: replace os.popen()/os.system() with subprocess; build find command list from FILE_PATTERNS so *.fits.fz is included
- markup.py: remove redundant zip.close() after with block
- markup.py: remove dead `preview` field from pic dict
- catalog.py: rename `type` variable to type_counts (shadowed built-in)
- catalog.py: wrap open(catalogfile) in with statement

HTML/JS:
- imagelib.html: replace <image> with <img> (two occurrences)
- imagelib.html: replace <font color> with <span style>; move flash message guard inside {% with %} so messages actually render
- imagelib.js: fix toggleSelect() to accept and use mode parameter
- imagelib.js: replace deprecated event.keyCode with event.key
- imagelib.js/catalog.py: fix typos (Reutrn, help.hmtl, Wuery)