### PR TITLE
Phase 3: Asterism integration, .fits.fz support, metadata filters (3a–3g)

### DIFF
--- a/doc/plan.md
+++ b/doc/plan.md
@@ -175,6 +175,24 @@ if basename.startswith('MN') and not basename.startswith('MNc'):
 
 Advance `VERSION` file from `v2.1.3` to `v3.1.0`.
 
+### 3g — Asterism drop folder date-subfolder organization
+
+**Requirement**: Asterism SFTP transfers arrive flat into `/home/nas/Eagle/Asterism/rfo/`. As the volume of files grows this will become unwieldy. Files must be moved into a `YYYY-MM-DD` subfolder (named from the `DATE-OBS` UTC date) during ingest, matching the convention used in `/home/nas/Eagle/SkyX/Images/`.
+
+**Decision**: Use UTC date from the `DATE-OBS` FITS header. For most RFO observing sessions the session stays within a single UTC date, so this is consistent with how the UI already groups images. No noon-to-noon or local-time adjustment is applied.
+
+**Implementation**: `fitsfiles.py` `_maybe_organize(filename, headers)` — called in `addFitsFile()` immediately after `parseFitsHeader()` returns, before `buildDatabaseRecord()` and before any DB insert. The method:
+1. Checks whether the file's parent directory is exactly `ASTERISM_DROP` (`/home/nas/Eagle/Asterism/rfo`); if not, returns the path unchanged.
+2. Extracts `DATE-OBS[:10]` for the subfolder name.
+3. Creates `ASTERISM_DROP/<YYYY-MM-DD>/` if it doesn't exist (`os.makedirs(..., exist_ok=True)`).
+4. Moves the file with `os.rename()` and returns the new path.
+
+Because the move happens before the path is recorded in the database, the stored `path` is always the final date-subfolder location. Files already in a subfolder (i.e., the `find` command picks them up on a later run) are untouched since their parent directory won't match `ASTERISM_DROP`.
+
+The `ASTERISM_DROP` constant is a class attribute on `FitsFiles`, overridable in tests.
+
+**Tests**: 4 new tests in `test_fitsfiles.py` — move + dir creation, non-drop-folder no-op, already-organized file no-op.
+
 ---
 
 ## Production Deployment

--- a/doc/plan.md
+++ b/doc/plan.md
@@ -177,14 +177,14 @@ Advance `VERSION` file from `v2.1.3` to `v3.1.0`.
 
 ### 3g — Asterism drop folder date-subfolder organization
 
-**Requirement**: Asterism SFTP transfers arrive flat into `/home/nas/Eagle/Asterism/rfo/`. As the volume of files grows this will become unwieldy. Files must be moved into a `YYYY-MM-DD` subfolder (named from the `DATE-OBS` UTC date) during ingest, matching the convention used in `/home/nas/Eagle/SkyX/Images/`.
+**Requirement**: Asterism SFTP transfers arrive flat into `/home/nas/Eagle/Asterism/rfo/`. As the volume of files grows this will become unwieldy. Files must be moved into a `YYYY/MM/DD` nested subfolder tree (named from the `DATE-OBS` UTC date) during ingest. The three-level hierarchy keeps the inode count per folder low and makes manual browsing straightforward.
 
 **Decision**: Use UTC date from the `DATE-OBS` FITS header. For most RFO observing sessions the session stays within a single UTC date, so this is consistent with how the UI already groups images. No noon-to-noon or local-time adjustment is applied.
 
 **Implementation**: `fitsfiles.py` `_maybe_organize(filename, headers)` — called in `addFitsFile()` immediately after `parseFitsHeader()` returns, before `buildDatabaseRecord()` and before any DB insert. The method:
 1. Checks whether the file's parent directory is exactly `ASTERISM_DROP` (`/home/nas/Eagle/Asterism/rfo`); if not, returns the path unchanged.
-2. Extracts `DATE-OBS[:10]` for the subfolder name.
-3. Creates `ASTERISM_DROP/<YYYY-MM-DD>/` if it doesn't exist (`os.makedirs(..., exist_ok=True)`).
+2. Splits `DATE-OBS[:10]` into `year`, `month`, `day`.
+3. Creates `ASTERISM_DROP/YYYY/MM/DD/` if it doesn't exist (`os.makedirs(..., exist_ok=True)`).
 4. Moves the file with `os.rename()` and returns the new path.
 
 Because the move happens before the path is recorded in the database, the stored `path` is always the final date-subfolder location. Files already in a subfolder (i.e., the `find` command picks them up on a later run) are untouched since their parent directory won't match `ASTERISM_DROP`.

--- a/fitsfiles.py
+++ b/fitsfiles.py
@@ -28,6 +28,9 @@ class FitsFiles:
     # Patterns of FITS filenames to search for (used to build `find` args dynamically)
     FILE_PATTERNS = ['*.fits', '*.fit', '*.fits.fz']
 
+    # Flat drop folder for Asterism uploads; files here are moved into date subfolders on ingest
+    ASTERISM_DROP = '/home/nas/Eagle/Asterism/rfo'
+
     # Calibration Frame Map of FITS lower(`IMAGETYP`) --> `target` name
     CFrames = {
         'dark frame':   'Dark Frame',
@@ -125,6 +128,19 @@ class FitsFiles:
             record['y'] = headers['NAXIS2']
         return(record)
 
+    def _maybe_organize(self, filename, headers):
+        '''If filename sits directly in ASTERISM_DROP, move it into a YYYY-MM-DD subfolder.'''
+        parent = os.path.dirname(os.path.abspath(filename))
+        if parent != os.path.abspath(self.ASTERISM_DROP):
+            return filename
+        date_str = headers['DATE-OBS'][:10]
+        dest_dir = os.path.join(parent, date_str)
+        os.makedirs(dest_dir, exist_ok=True)
+        dest = os.path.join(dest_dir, os.path.basename(filename))
+        os.rename(filename, dest)
+        logging.info("Organized {} -> {}".format(filename, dest))
+        return dest
+
     def fits2png(self, record):
         '''Generate and png preview and thumbnail images; return updated database record.'''
 
@@ -218,6 +234,7 @@ class FitsFiles:
         headers = self.parseFitsHeader(filename)
         if (not headers):
             return(0)
+        filename = self._maybe_organize(filename, headers)
         record = self.buildDatabaseRecord(filename, headers)
         logging.debug(">>> addFitsFile: imagetype: {}".format(record['imagetype']))
         record = self.fits2png(record)

--- a/fitsfiles.py
+++ b/fitsfiles.py
@@ -129,12 +129,12 @@ class FitsFiles:
         return(record)
 
     def _maybe_organize(self, filename, headers):
-        '''If filename sits directly in ASTERISM_DROP, move it into a YYYY-MM-DD subfolder.'''
+        '''If filename sits directly in ASTERISM_DROP, move it into a YYYY/MM/DD subfolder.'''
         parent = os.path.dirname(os.path.abspath(filename))
         if parent != os.path.abspath(self.ASTERISM_DROP):
             return filename
-        date_str = headers['DATE-OBS'][:10]
-        dest_dir = os.path.join(parent, date_str)
+        year, month, day = headers['DATE-OBS'][:10].split('-')
+        dest_dir = os.path.join(parent, year, month, day)
         os.makedirs(dest_dir, exist_ok=True)
         dest = os.path.join(dest_dir, os.path.basename(filename))
         os.rename(filename, dest)

--- a/tests/test_fitsfiles.py
+++ b/tests/test_fitsfiles.py
@@ -240,26 +240,26 @@ def test_build_record_direct_rfo_metadata(ff):
 # ---------------------------------------------------------------------------
 
 def test_maybe_organize_moves_file_to_date_subfolder(ff, tmp_path):
-    """File in ASTERISM_DROP is moved into a YYYY-MM-DD subfolder."""
+    """File in ASTERISM_DROP is moved into a YYYY/MM/DD subfolder."""
     drop = tmp_path / 'rfo'
     drop.mkdir()
     fits_file = drop / 'image.fits.fz'
     fits_file.write_bytes(b'')
     ff.ASTERISM_DROP = str(drop)
     new_path = ff._maybe_organize(str(fits_file), {'DATE-OBS': '2026-07-11T03:45:00.000'})
-    assert new_path == str(drop / '2026-07-11' / 'image.fits.fz')
+    assert new_path == str(drop / '2026' / '07' / '11' / 'image.fits.fz')
     assert os.path.exists(new_path)
     assert not os.path.exists(str(fits_file))
 
 
 def test_maybe_organize_creates_date_dir(ff, tmp_path):
-    """ASTERISM_DROP/<date>/ is created if it doesn't already exist."""
+    """ASTERISM_DROP/YYYY/MM/DD/ tree is created if it doesn't already exist."""
     drop = tmp_path / 'rfo'
     drop.mkdir()
     (drop / 'image.fits.fz').write_bytes(b'')
     ff.ASTERISM_DROP = str(drop)
     ff._maybe_organize(str(drop / 'image.fits.fz'), {'DATE-OBS': '2026-07-11T03:45:00.000'})
-    assert (drop / '2026-07-11').is_dir()
+    assert (drop / '2026' / '07' / '11').is_dir()
 
 
 def test_maybe_organize_ignores_non_drop_folder(ff, tmp_path):
@@ -275,9 +275,9 @@ def test_maybe_organize_ignores_non_drop_folder(ff, tmp_path):
 
 
 def test_maybe_organize_ignores_file_already_in_date_subfolder(ff, tmp_path):
-    """File already in a date subfolder is not moved again."""
+    """File already in a YYYY/MM/DD subfolder is not moved again."""
     drop = tmp_path / 'rfo'
-    date_dir = drop / '2026-07-11'
+    date_dir = drop / '2026' / '07' / '11'
     date_dir.mkdir(parents=True)
     fits_file = date_dir / 'image.fits.fz'
     fits_file.write_bytes(b'')

--- a/tests/test_fitsfiles.py
+++ b/tests/test_fitsfiles.py
@@ -235,6 +235,58 @@ def test_build_record_direct_rfo_metadata(ff):
     assert record['observer'] == 'G. Loyer'
 
 
+# ---------------------------------------------------------------------------
+# _maybe_organize — Asterism drop folder date-subfolder organization
+# ---------------------------------------------------------------------------
+
+def test_maybe_organize_moves_file_to_date_subfolder(ff, tmp_path):
+    """File in ASTERISM_DROP is moved into a YYYY-MM-DD subfolder."""
+    drop = tmp_path / 'rfo'
+    drop.mkdir()
+    fits_file = drop / 'image.fits.fz'
+    fits_file.write_bytes(b'')
+    ff.ASTERISM_DROP = str(drop)
+    new_path = ff._maybe_organize(str(fits_file), {'DATE-OBS': '2026-07-11T03:45:00.000'})
+    assert new_path == str(drop / '2026-07-11' / 'image.fits.fz')
+    assert os.path.exists(new_path)
+    assert not os.path.exists(str(fits_file))
+
+
+def test_maybe_organize_creates_date_dir(ff, tmp_path):
+    """ASTERISM_DROP/<date>/ is created if it doesn't already exist."""
+    drop = tmp_path / 'rfo'
+    drop.mkdir()
+    (drop / 'image.fits.fz').write_bytes(b'')
+    ff.ASTERISM_DROP = str(drop)
+    ff._maybe_organize(str(drop / 'image.fits.fz'), {'DATE-OBS': '2026-07-11T03:45:00.000'})
+    assert (drop / '2026-07-11').is_dir()
+
+
+def test_maybe_organize_ignores_non_drop_folder(ff, tmp_path):
+    """Files not in ASTERISM_DROP are returned unchanged."""
+    other = tmp_path / 'other'
+    other.mkdir()
+    fits_file = other / 'image.fits.fz'
+    fits_file.write_bytes(b'')
+    ff.ASTERISM_DROP = str(tmp_path / 'rfo')  # different directory
+    new_path = ff._maybe_organize(str(fits_file), {'DATE-OBS': '2026-07-11T03:45:00.000'})
+    assert new_path == str(fits_file)
+    assert os.path.exists(str(fits_file))
+
+
+def test_maybe_organize_ignores_file_already_in_date_subfolder(ff, tmp_path):
+    """File already in a date subfolder is not moved again."""
+    drop = tmp_path / 'rfo'
+    date_dir = drop / '2026-07-11'
+    date_dir.mkdir(parents=True)
+    fits_file = date_dir / 'image.fits.fz'
+    fits_file.write_bytes(b'')
+    ff.ASTERISM_DROP = str(drop)
+    new_path = ff._maybe_organize(str(fits_file), {'DATE-OBS': '2026-07-11T03:45:00.000'})
+    assert new_path == str(fits_file)
+    assert os.path.exists(str(fits_file))
+
+
 def test_build_record_calibration_no_metadata(ff):
     """Cal frames: organization/project/observatory/observer must be absent from record."""
     headers = {


### PR DESCRIPTION
## Summary

- **3a** — Asterism SFTP drop point: `internal-sftp` restricted account, authorized_keys install documented in `doc/plan.md`
- **3b** — Fix `.fits.fz` extension handling in `fits2png`; test DB isolation via `FITSDB_FILE`
- **3c** — Download format choice: `.fits.fz` pass-through or in-memory decompression to `.fits`
- **3d** — RFO calibration filter: skip `MN`-prefixed uncalibrated files; pass `MNc`-prefixed and non-RFO files
- **3e** — Org/project/observatory/observer metadata: ingest from FITS headers, four new DB columns, three filter dropdowns in UI, `update:orgproject` migration
- **3f** — VERSION bumped to `v3.1.0`
- **3g** — Asterism drop folder organization: files arriving flat in `/home/nas/Eagle/Asterism/rfo/` are moved into `YYYY-MM-DD` subfolders (from `DATE-OBS`) during ingest, before the path is written to the DB
- **ops** — `bin/deploy.sh` with code backup, stash handling, migration detection, wsgi reload, and rollback instructions; README deployment section

## Test plan

- [ ] All 67 unit/integration tests pass: `IMAGELIB_SECRET_KEY=x python -m pytest tests/ -v`
- [ ] Deploy to production: `sudo -u nas /home/nas/flask/imagelib/bin/deploy.sh`, run `update:orgproject` migration when prompted
- [ ] Confirm Asterism SFTP drop works and new files land in `/home/nas/Eagle/Asterism/rfo/`
- [ ] Confirm ingest moves files to `/home/nas/Eagle/Asterism/rfo/YYYY-MM-DD/` and records the date-subfolder path in the DB
- [ ] Verify both `.fits.fz` and `.fits` download format options work in the UI
- [ ] Confirm `MN`-prefixed uncalibrated files are skipped in the cron log
- [ ] Once Asterism images are ingested, verify org/project/observatory/observer filter dropdowns appear and filter correctly
- [ ] Confirm version shows `v3.1.0` in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)